### PR TITLE
スポンサー申し込みボタン&登壇申し込みボタンにexternal linkのアイコンを追加しました

### DIFF
--- a/components/top/Wantspeaker.vue
+++ b/components/top/Wantspeaker.vue
@@ -14,7 +14,7 @@
             </p>
             <a class="p-wantSpeaker_btn"
                     href="https://docs.google.com/forms/d/e/1FAIpQLSeczBxHUOA8PIBWj3M-nJzzwcwyegAtjO4sUXgLXBHDUYYnng/viewform" target="_blank"
-            >登壇申し込み</a>
+            >登壇申し込み<i class="fas fa-external-link-alt"></i></a>
           </div>
         </div>
       </div>
@@ -78,6 +78,12 @@
 
   &_btn {
     @include c-btn;
+    
+     i {
+      position: absolute;
+      right: 5%;
+      top:32%;
+    }
   }
 }
 

--- a/components/top/Wantsponsor.vue
+++ b/components/top/Wantsponsor.vue
@@ -13,7 +13,7 @@
             </p>
             <a class="p-wantSponsor_btn"
                href="https://docs.google.com/forms/d/e/1FAIpQLSewyGycmlpy9pkd3Fqp3FtanZopeoY4DTjcuofvdY15BfqDaA/viewform" target="_blank"
-            >スポンサー申込み</a>
+            >スポンサー申込み<i class="fas fa-external-link-alt"></i></a>
           </div>
         </div>
       </div>
@@ -78,6 +78,12 @@
 
   &_btn {
     @include c-btn;
+
+    i {
+      position: absolute;
+      right: 5%;
+      top:20%;
+    }
   }
 }
   

--- a/components/top/Wantsponsor.vue
+++ b/components/top/Wantsponsor.vue
@@ -82,7 +82,7 @@
     i {
       position: absolute;
       right: 5%;
-      top:20%;
+      top:32%;
     }
   }
 }


### PR DESCRIPTION
#27 の対応です
textを中央寄せしつつ、アイコンだけ右に寄せる方法がこれしかわからなかったので、position:absoluteでやってみました。
アンチパターンな気もしますが、よろしくお願いします。

fontowesomeにXDの外部リンクアイコンと同じものがなかったので、使えるものを使用しました